### PR TITLE
feat: implement GDI screen capture and two-pass Gaussian blur

### DIFF
--- a/src/overlay/blur.rs
+++ b/src/overlay/blur.rs
@@ -1,3 +1,74 @@
-pub fn apply_blur() {
-    todo!("Implement Gaussian blur")
+pub fn generate_gaussian_kernel(sigma: f32) -> Vec<f32> {
+    let radius = (sigma * 3.0).ceil() as usize;
+    let size = radius * 2 + 1;
+    let mut kernel = vec![0.0f32; size];
+    let mut sum = 0.0f32;
+
+    let two_sigma_sq = 2.0 * sigma * sigma;
+    let root_two_pi_sigma = (two_sigma_sq * std::f32::consts::PI).sqrt();
+
+    for i in 0..size {
+        let x = i as f32 - radius as f32;
+        kernel[i] = (-x * x / two_sigma_sq).exp() / root_two_pi_sigma;
+        sum += kernel[i];
+    }
+
+    for val in kernel.iter_mut() {
+        *val /= sum;
+    }
+
+    kernel
+}
+
+#[inline(always)]
+fn get_pixel(data: &[u8], width: usize, _height: usize, x: usize, y: usize) -> (f32, f32, f32) {
+    let idx = (y * width + x) * 4;
+    (data[idx] as f32, data[idx+1] as f32, data[idx+2] as f32)
+}
+
+pub fn blur(src: &[u8], width: usize, height: usize, sigma: f32) -> Vec<u8> {
+    let kernel = generate_gaussian_kernel(sigma);
+    let radius = kernel.len() / 2;
+    let mut temp = vec![0u8; src.len()];
+    let mut dst = vec![0u8; src.len()];
+
+    // Horizontal pass
+    for y in 0..height {
+        for x in 0..width {
+            let (mut r, mut g, mut b) = (0.0f32, 0.0f32, 0.0f32);
+            for (k, &weight) in kernel.iter().enumerate() {
+                let ix = (x as isize + k as isize - radius as isize).clamp(0, width as isize - 1) as usize;
+                let (pr, pg, pb) = get_pixel(src, width, height, ix, y);
+                r += pr * weight;
+                g += pg * weight;
+                b += pb * weight;
+            }
+            let idx = (y * width + x) * 4;
+            temp[idx] = r as u8;
+            temp[idx+1] = g as u8;
+            temp[idx+2] = b as u8;
+            temp[idx+3] = 255;
+        }
+    }
+
+    // Vertical pass
+    for y in 0..height {
+        for x in 0..width {
+            let (mut r, mut g, mut b) = (0.0f32, 0.0f32, 0.0f32);
+            for (k, &weight) in kernel.iter().enumerate() {
+                let iy = (y as isize + k as isize - radius as isize).clamp(0, height as isize - 1) as usize;
+                let (pr, pg, pb) = get_pixel(&temp, width, height, x, iy);
+                r += pr * weight;
+                g += pg * weight;
+                b += pb * weight;
+            }
+            let idx = (y * width + x) * 4;
+            dst[idx] = r as u8;
+            dst[idx+1] = g as u8;
+            dst[idx+2] = b as u8;
+            dst[idx+3] = 255;
+        }
+    }
+
+    dst
 }

--- a/src/overlay/capture.rs
+++ b/src/overlay/capture.rs
@@ -1,3 +1,75 @@
-pub fn capture_screen() {
-    todo!("Implement screen capture")
+use windows::{
+    core::*,
+    Win32::Graphics::Gdi::*,
+    Win32::UI::WindowsAndMessaging::*,
+};
+
+pub struct CapturedScreen {
+    pub width: i32,
+    pub height: i32,
+    pub data: Vec<u8>, // BGRA pixels
+}
+
+pub fn capture_virtual_screen() -> Result<CapturedScreen> {
+    unsafe {
+        let x = GetSystemMetrics(SM_XVIRTUALSCREEN);
+        let y = GetSystemMetrics(SM_YVIRTUALSCREEN);
+        let width = GetSystemMetrics(SM_CXVIRTUALSCREEN);
+        let height = GetSystemMetrics(SM_CYVIRTUALSCREEN);
+
+        let h_screen_dc = GetDC(None);
+        let h_memory_dc = CreateCompatibleDC(h_screen_dc);
+        let h_bitmap = CreateCompatibleBitmap(h_screen_dc, width, height);
+
+        let h_old_obj = SelectObject(h_memory_dc, h_bitmap);
+
+        BitBlt(
+            h_memory_dc,
+            0,
+            0,
+            width,
+            height,
+            h_screen_dc,
+            x,
+            y,
+            SRCCOPY,
+        )?;
+
+        let mut bmi = BITMAPINFO {
+            bmiHeader: BITMAPINFOHEADER {
+                biSize: std::mem::size_of::<BITMAPINFOHEADER>() as u32,
+                biWidth: width,
+                biHeight: -height, // Negative for top-down DIB
+                biPlanes: 1,
+                biBitCount: 32,
+                biCompression: BI_RGB.0,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let mut data = vec![0u8; (width * height * 4) as usize];
+
+        GetDIBits(
+            h_screen_dc,
+            h_bitmap,
+            0,
+            height as u32,
+            Some(data.as_mut_ptr() as *mut _),
+            &mut bmi,
+            DIB_RGB_COLORS,
+        );
+
+        // Cleanup
+        let _ = SelectObject(h_memory_dc, h_old_obj);
+        let _ = DeleteObject(h_bitmap);
+        let _ = DeleteDC(h_memory_dc);
+        ReleaseDC(None, h_screen_dc);
+
+        Ok(CapturedScreen {
+            width,
+            height,
+            data,
+        })
+    }
 }

--- a/tests/blur_tests.rs
+++ b/tests/blur_tests.rs
@@ -1,4 +1,35 @@
+use pausecat::overlay::blur::{blur, generate_gaussian_kernel};
+
 #[test]
-fn test_blur_placeholder() {
-    assert!(true);
+fn test_gaussian_kernel_sum() {
+    let kernel = generate_gaussian_kernel(2.0);
+    let sum: f32 = kernel.iter().sum();
+    assert!((sum - 1.0).abs() < 1e-5);
+}
+
+#[test]
+fn test_blur_small_image() {
+    // 4x4 black image with one white pixel in the middle
+    let width = 4;
+    let height = 4;
+    let mut data = vec![0u8; width * height * 4];
+    
+    // Set (2, 2) to white
+    let idx = (2 * width + 2) * 4;
+    data[idx] = 255;
+    data[idx+1] = 255;
+    data[idx+2] = 255;
+    data[idx+3] = 255;
+
+    let blurred = blur(&data, width, height, 1.0);
+    
+    assert_eq!(blurred.len(), data.len());
+    
+    // The white pixel should be spread to its neighbors
+    // Check if some other pixel is now non-zero
+    let neighbor_idx = (2 * width + 1) * 4;
+    assert!(blurred[neighbor_idx] > 0);
+    
+    // The original white pixel should now be less than 255
+    assert!(blurred[idx] < 255);
 }

--- a/tests/capture_tests.rs
+++ b/tests/capture_tests.rs
@@ -1,0 +1,12 @@
+use pausecat::overlay::capture::capture_virtual_screen;
+
+#[test]
+fn test_capture_virtual_screen() {
+    let result = capture_virtual_screen();
+    assert!(result.is_ok());
+    
+    let captured = result.unwrap();
+    assert!(captured.width > 0);
+    assert!(captured.height > 0);
+    assert_eq!(captured.data.len(), (captured.width * captured.height * 4) as usize);
+}


### PR DESCRIPTION
   - Screen Capture Subsystem:
       - Implemented capture_virtual_screen in src/overlay/capture.rs.
       - Uses GDI BitBlt to capture the entire virtual desktop (multi-monitor support).
       - Uses GetDIBits to extract raw BGRA pixel data into a Vec<u8>.
       - Ensures proper cleanup of all Win32 GDI handles (HDC, HBITMAP).
   - Gaussian Blur Subsystem:
       - Implemented a high-performance two-pass separable Gaussian blur in src/overlay/blur.rs.
       - Kernel is pre-calculated based on a configurable sigma.
       - Optimized with #[inline(always)] for the hot pixel-fetching path.
   - Verification:
       - Added unit tests in tests/blur_tests.rs to verify kernel math and pixel-spreading logic.
       - Added integration test in tests/capture_tests.rs to verify real screen capture dimensions and data integrity.
       - Verified all tests pass and the project builds without warnings.