### PR TITLE
Settings UI implementation

### DIFF
--- a/assets/app.manifest
+++ b/assets/app.manifest
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <assemblyIdentity
+    version="1.0.0.0"
+    processorArchitecture="*"
+    name="PauseCat"
+    type="win32"
+  />
+  <description>PauseCat Break Reminder</description>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/assets/settings.html
+++ b/assets/settings.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PauseCat Settings</title>
+    <style>
+        body {
+            font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
+            background-color: #f3f4f6;
+            color: #1f2937;
+            margin: 0;
+            padding: 20px;
+            display: flex;
+            flex-direction: column;
+            gap: 20px;
+        }
+        .header {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+        }
+        .header h1 {
+            font-size: 1.5rem;
+            margin: 0;
+            color: #4b5563;
+        }
+        .card {
+            background: white;
+            padding: 20px;
+            border-radius: 8px;
+            shadow: 0 1px 3px rgba(0,0,0,0.1);
+        }
+        .group {
+            margin-bottom: 15px;
+        }
+        label {
+            display: block;
+            font-size: 0.875rem;
+            font-weight: 500;
+            margin-bottom: 5px;
+        }
+        input[type="number"], select {
+            width: 100%;
+            padding: 8px;
+            border: 1px solid #d1d5db;
+            border-radius: 4px;
+            box-sizing: border-box;
+        }
+        .checkbox-group {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+        .actions {
+            display: flex;
+            justify-content: flex-end;
+            gap: 10px;
+            margin-top: 10px;
+        }
+        button {
+            padding: 8px 16px;
+            border-radius: 4px;
+            font-size: 0.875rem;
+            cursor: pointer;
+            transition: all 0.2s;
+        }
+        .btn-primary {
+            background-color: #3b82f6;
+            color: white;
+            border: none;
+        }
+        .btn-primary:hover { background-color: #2563eb; }
+        .btn-secondary {
+            background-color: white;
+            color: #374151;
+            border: 1px solid #d1d5db;
+        }
+        .btn-secondary:hover { background-color: #f9fafb; }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <span style="font-size: 2rem;">🐾</span>
+        <h1>PauseCat Settings</h1>
+    </div>
+
+    <div class="card">
+        <div class="group">
+            <label for="work_duration">Work Duration (minutes)</label>
+            <input type="number" id="work_duration" min="5" max="240" step="5">
+        </div>
+
+        <div class="group">
+            <label for="break_duration">Break Duration (minutes)</label>
+            <input type="number" id="break_duration" min="1" max="30" step="1">
+        </div>
+
+        <div class="group">
+            <label for="mode">Break Mode</label>
+            <select id="mode">
+                <option value="soft">Soft (Can skip)</option>
+                <option value="hard">Hard (Immersive)</option>
+            </select>
+        </div>
+
+        <div class="group checkbox-group">
+            <input type="checkbox" id="autostart">
+            <label for="autostart">Launch on Windows startup</label>
+        </div>
+
+        <div class="actions">
+            <button class="btn-secondary" onclick="window.chrome.webview.postMessage({action: 'close'})">Cancel</button>
+            <button class="btn-primary" onclick="save()">Save Changes</button>
+        </div>
+    </div>
+
+    <script>
+        function save() {
+            const settings = {
+                work_duration_secs: document.getElementById('work_duration').value * 60,
+                break_duration_secs: document.getElementById('break_duration').value * 60,
+                mode: document.getElementById('mode').value,
+                autostart: document.getElementById('autostart').checked,
+                overlay_animation: "cat.webp"
+            };
+            window.chrome.webview.postMessage({ action: "save", settings: settings });
+        }
+
+        window.chrome.webview.addEventListener('message', event => {
+            if (event.data.action === "load") {
+                const s = event.data.settings;
+                document.getElementById('work_duration').value = s.work_duration_secs / 60;
+                document.getElementById('break_duration').value = s.break_duration_secs / 60;
+                document.getElementById('mode').value = s.mode;
+                document.getElementById('autostart').checked = s.autostart;
+            }
+        });
+    </script>
+</body>
+</html>

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,7 @@
 fn main() {
-    // build.rs will eventually use winres to embed manifest and icon
+    if std::env::var("CARGO_CFG_TARGET_OS").unwrap() == "windows" {
+        let mut res = winres::WindowsResource::new();
+        res.set_manifest_file("assets/app.manifest");
+        res.compile().unwrap();
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod settings;
+pub mod settings_ui;
 pub mod tray;
 pub mod timer;
 pub mod overlay;

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use pausecat::tray::TrayIcon;
 use pausecat::events::AppEvent;
 use pausecat::timer;
 use pausecat::overlay::{OverlayWindow, capture, blur};
+use pausecat::settings_ui::SettingsWindow;
 
 const TIMER_ID_CHANNEL: usize = 1;
 
@@ -19,7 +20,8 @@ struct App {
     event_tx: mpsc::Sender<AppEvent>,
     event_rx: mpsc::Receiver<AppEvent>,
     tray: Option<TrayIcon>,
-    overlay: Option<OverlayWindow>,
+    reminder_overlay: Option<OverlayWindow>,
+    settings_window: Option<SettingsWindow>,
 }
 
 impl App {
@@ -34,7 +36,8 @@ impl App {
             event_tx,
             event_rx,
             tray: None,
-            overlay: None,
+            reminder_overlay: None,
+            settings_window: None,
         }
     }
 
@@ -61,12 +64,14 @@ impl App {
     fn handle_event(&mut self, event: AppEvent) {
         match event {
             AppEvent::ShowOverlay => {
-                if self.overlay.is_none() {
+                if self.reminder_overlay.is_none() {
                     self.show_overlay();
                 }
             }
             AppEvent::HideOverlay | AppEvent::UserDismissed => {
-                self.overlay = None;
+                // UserDismissed can come from both Overlay and Settings
+                self.reminder_overlay = None;
+                self.settings_window = None;
             }
             AppEvent::TogglePause => {
                 let new_paused = !self.paused.load(Ordering::Relaxed);
@@ -76,12 +81,18 @@ impl App {
                 }
             }
             AppEvent::OpenSettings => {
-                println!("Open Settings requested");
+                if self.settings_window.is_none() {
+                    let current_settings = self.settings.read().unwrap().clone();
+                    if let Ok(win) = SettingsWindow::new(self.event_tx.clone(), current_settings) {
+                        self.settings_window = Some(win);
+                    }
+                }
             }
             AppEvent::ConfigChanged(new_settings) => {
                 let mut settings = self.settings.write().unwrap();
                 *settings = new_settings;
                 let _ = settings.save();
+                println!("Settings updated and saved.");
             }
             AppEvent::Quit => {
                 unsafe { PostQuitMessage(0) };
@@ -96,7 +107,7 @@ impl App {
             
             if let Ok(overlay) = OverlayWindow::new(self.event_tx.clone(), captured.width, captured.height, blurred) {
                 overlay.fade_in();
-                self.overlay = Some(overlay);
+                self.reminder_overlay = Some(overlay);
             }
         }
     }

--- a/src/settings_ui.rs
+++ b/src/settings_ui.rs
@@ -1,0 +1,142 @@
+use std::sync::mpsc::Sender;
+use windows::core::*;
+use windows::Win32::Foundation::*;
+use windows::Win32::UI::WindowsAndMessaging::*;
+use windows::Win32::Graphics::Gdi::*;
+use windows::Win32::System::Com::*;
+use windows::Win32::System::LibraryLoader::*;
+use webview2_com::*;
+use webview2_com::Microsoft::Web::WebView2::Win32::*;
+use crate::events::AppEvent;
+use crate::settings::Settings;
+
+pub struct SettingsWindow {
+    pub hwnd: HWND,
+}
+
+impl SettingsWindow {
+    pub fn new(sender: Sender<AppEvent>, current_settings: Settings) -> windows::core::Result<Self> {
+        unsafe {
+            let instance: HINSTANCE = GetModuleHandleW(None)?.into();
+            let class_name = w!("PauseCatSettingsClass");
+
+            let wnd_class = WNDCLASSEXW {
+                cbSize: std::mem::size_of::<WNDCLASSEXW>() as u32,
+                lpfnWndProc: Some(settings_wnd_proc),
+                hInstance: instance,
+                lpszClassName: class_name,
+                hCursor: LoadCursorW(None, IDC_ARROW)?,
+                hbrBackground: HBRUSH((COLOR_WINDOW.0 + 1) as *mut _),
+                ..Default::default()
+            };
+
+            RegisterClassExW(&wnd_class);
+
+            let hwnd = CreateWindowExW(
+                WINDOW_EX_STYLE::default(),
+                class_name,
+                w!("PauseCat Settings"),
+                WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU,
+                CW_USEDEFAULT, CW_USEDEFAULT, 400, 500,
+                None, None, Some(instance), None
+            )?;
+
+            Self::init_webview(hwnd, sender, current_settings)?;
+
+            let _ = ShowWindow(hwnd, SW_SHOW);
+            let _ = UpdateWindow(hwnd);
+
+            Ok(Self { hwnd })
+        }
+    }
+
+    fn init_webview(hwnd: HWND, sender: Sender<AppEvent>, settings: Settings) -> windows::core::Result<()> {
+        unsafe {
+            CreateCoreWebView2EnvironmentWithOptions(None, None, None, 
+                &CreateCoreWebView2EnvironmentCompletedHandler::create(
+                    Box::new(move |result, env| {
+                        result?;
+                        let env = env.ok_or_else(|| windows::core::Error::from_hresult(HRESULT(-1)))?;
+                        
+                        env.CreateCoreWebView2Controller(hwnd, 
+                            &CreateCoreWebView2ControllerCompletedHandler::create(
+                                Box::new(move |result, controller| {
+                                    result?;
+                                    let controller = controller.ok_or_else(|| windows::core::Error::from_hresult(HRESULT(-1)))?;
+                                    
+                                    let mut rect = RECT::default();
+                                    let _ = GetClientRect(hwnd, &mut rect);
+                                    let _ = controller.Bounds(&mut rect);
+
+                                    let webview = controller.CoreWebView2()?;
+                                    let webview_settings = webview.Settings()?;
+                                    let _ = webview_settings.SetIsWebMessageEnabled(true);
+                                    let _ = webview_settings.SetAreDevToolsEnabled(false);
+                                    let _ = webview_settings.SetAreDefaultContextMenusEnabled(false);
+
+                                    let sender_clone = sender.clone();
+                                    let mut token = 0i64;
+                                    let _ = webview.add_WebMessageReceived(
+                                        &WebMessageReceivedEventHandler::create(
+                                            Box::new(move |_, args| {
+                                                if let Some(args) = args {
+                                                    let mut message = PWSTR::null();
+                                                    if args.WebMessageAsJson(&mut message).is_ok() {
+                                                        let json = message.to_string().unwrap_or_default();
+                                                        if json.contains("\"action\":\"save\"") {
+                                                            if let Ok(data) = serde_json::from_str::<serde_json::Value>(&json) {
+                                                                if let Ok(new_settings) = serde_json::from_value::<Settings>(data["settings"].clone()) {
+                                                                    let _ = sender_clone.send(AppEvent::ConfigChanged(new_settings));
+                                                                    let _ = sender_clone.send(AppEvent::UserDismissed); 
+                                                                }
+                                                            }
+                                                        } else if json.contains("\"action\":\"close\"") {
+                                                            let _ = sender_clone.send(AppEvent::UserDismissed);
+                                                        }
+                                                        CoTaskMemFree(Some(message.0 as *const _));
+                                                    }
+                                                }
+                                                Ok(())
+                                            })
+                                        ),
+                                        &mut token
+                                    );
+
+                                    let html = include_str!("../assets/settings.html");
+                                    let hhtml = HSTRING::from(html);
+                                    let _ = webview.NavigateToString(PCWSTR(hhtml.as_ptr()));
+
+                                    let json_settings = serde_json::to_string(&settings).unwrap_or_default();
+                                    let msg = format!("{{\"action\":\"load\", \"settings\": {}}}", json_settings);
+                                    let hmsg = HSTRING::from(msg);
+                                    let _ = webview.PostWebMessageAsJson(PCWSTR(hmsg.as_ptr()));
+
+                                    Ok(())
+                                })
+                            )
+                        )?;
+                        Ok(())
+                    })
+                )
+            )?;
+        }
+        Ok(())
+    }
+}
+
+impl Drop for SettingsWindow {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = DestroyWindow(self.hwnd);
+        }
+    }
+}
+
+unsafe extern "system" fn settings_wnd_proc(hwnd: HWND, msg: u32, wparam: WPARAM, lparam: LPARAM) -> LRESULT {
+    match msg {
+        WM_DESTROY => {
+            LRESULT(0)
+        }
+        _ => DefWindowProcW(hwnd, msg, wparam, lparam),
+    }
+}


### PR DESCRIPTION
- Settings UI Subsystem:
       - Created assets/settings.html: A modern, responsive settings form allowing users to configure work/break intervals, toggle the break mode (Soft/Hard), and enable/disable
         autostart.
       - Implemented src/settings_ui.rs: Manages a secondary Win32 window hosting the WebView2 settings page.
       - Live Config Bridge: Implemented a two-way bridge:
           - Rust to JS: Sends current application settings to the form on initialization.
           - JS to Rust: Sends updated settings back to the main loop, which triggers a save to the JSON config and an immediate internal state update.
- DPI Awareness:
       - Created assets/app.manifest to declare the application as Per-Monitor DPI aware.
       - Updated build.rs to embed this manifest into the final executable using the winres crate, ensuring the UI remains crisp on all displays.
- Project Refinement:
       - Renamed internal state variables for clarity (e.g., reminder_overlay vs settings_window).
       - Handled the settings window lifecycle (creation, data binding, and cleanup).