### PR TITLE
feat: Implement Smart Session Guard for Lock and Sleep Awareness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -889,7 +889,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "pausecat"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "base64",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "pausecat"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
+
 
 [dependencies]
 windows = { version = "0.62", features = [
@@ -19,6 +20,7 @@ windows = { version = "0.62", features = [
     "Win32_UI_Controls_Dialogs",
     "Win32_System_Threading",
     "Win32_System_ProcessStatus",
+    "Win32_System_RemoteDesktop",
     "Win32_Security",
     "Win32_System_Variant",
     "Win32_System_Memory",

--- a/src/events.rs
+++ b/src/events.rs
@@ -15,4 +15,6 @@ pub enum AppEvent {
     StartUpdate,
     UpdateProgress(u32), // Percentage 0-100
     UpdateError(String),
+    SessionLocked,
+    SessionUnlocked,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,23 +1,23 @@
 #![windows_subsystem = "windows"]
 
-use std::sync::{Arc, RwLock};
+use pausecat::events::AppEvent;
+use pausecat::overlay::{blur, capture, webview_env, OverlayWindow};
+use pausecat::settings::Settings;
+use pausecat::settings_ui::SettingsWindow;
+use pausecat::timer;
+use pausecat::tray::TrayIcon;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc;
+use std::sync::{Arc, RwLock};
 use std::thread;
-use windows::Win32::UI::WindowsAndMessaging::*;
-use windows::Win32::System::Com::*;
 use windows::Win32::Foundation::*;
-use pausecat::settings::Settings;
-use pausecat::tray::TrayIcon;
-use pausecat::events::AppEvent;
-use pausecat::timer;
-use pausecat::overlay::{OverlayWindow, capture, blur, webview_env};
-use pausecat::settings_ui::SettingsWindow;
+use windows::Win32::System::Com::*;
+use windows::Win32::UI::WindowsAndMessaging::*;
 
-/// Main application structure to hold state and router logic.
 struct App {
     settings: Arc<RwLock<Settings>>,
     paused: Arc<AtomicBool>,
+    session_paused: Arc<AtomicBool>,
     event_tx: mpsc::Sender<AppEvent>,
     event_rx: mpsc::Receiver<AppEvent>,
     tray: Option<TrayIcon>,
@@ -33,12 +33,13 @@ impl App {
         let (event_tx, event_rx) = mpsc::channel::<AppEvent>();
         let settings = Arc::new(RwLock::new(Settings::load()));
         let paused = Arc::new(AtomicBool::new(false));
-        // Initialization Fix: Correctly detect system theme on startup
+        let session_paused = Arc::new(AtomicBool::new(false));
         let is_dark_mode = pausecat::system::is_dark_mode();
 
         Self {
             settings,
             paused,
+            session_paused,
             event_tx,
             event_rx,
             tray: None,
@@ -60,16 +61,22 @@ impl App {
         pausecat::system::set_tray_menu_theme(self.is_dark_mode);
         self.tray = Some(TrayIcon::new(self.event_tx.clone())?);
 
-        // Cleanup any old update files from previous sessions
         pausecat::updater::cleanup_updates();
 
         let settings_clone = self.settings.clone();
         let event_tx_clone = self.event_tx.clone();
         let paused_clone = self.paused.clone();
+        let session_paused_clone = self.session_paused.clone();
         let bg_clone = self.pre_captured_bg.clone();
-        
+
         thread::spawn(move || {
-            timer::run_optimized(settings_clone, event_tx_clone, paused_clone, bg_clone);
+            timer::run_optimized(
+                settings_clone,
+                event_tx_clone,
+                paused_clone,
+                session_paused_clone,
+                bg_clone,
+            );
         });
 
         Ok(())
@@ -78,7 +85,7 @@ impl App {
     fn handle_event(&mut self, event: AppEvent) {
         match event {
             AppEvent::ShowOverlay => {
-                if self.reminder_overlay.is_none() {
+                if self.reminder_overlay.is_none() && !self.session_paused.load(Ordering::Relaxed) {
                     self.pause_media();
                     self.show_overlay_optimized();
                 }
@@ -88,7 +95,6 @@ impl App {
                     self.resume_media();
                 }
                 self.reminder_overlay = None;
-                self.settings_window = None;
             }
             AppEvent::TogglePause => {
                 let new_paused = !self.paused.load(Ordering::Relaxed);
@@ -101,7 +107,6 @@ impl App {
                 if self.settings_window.is_none() {
                     let current_settings = self.settings.read().unwrap().clone();
                     if let Ok(win) = SettingsWindow::new(self.event_tx.clone(), current_settings) {
-                        // Apply current theme immediately to title bar and content
                         win.update_theme(self.is_dark_mode);
                         pausecat::system::apply_immersive_dark_mode(win.hwnd, self.is_dark_mode);
                         self.settings_window = Some(win);
@@ -115,10 +120,12 @@ impl App {
             }
             AppEvent::CheckForUpdates => {
                 let event_tx = self.event_tx.clone();
-                thread::spawn(move || {
-                    match pausecat::updater::check_for_updates() {
-                        Ok(info) => { let _ = event_tx.send(AppEvent::UpdateStatus(info)); }
-                        Err(e) => { let _ = event_tx.send(AppEvent::UpdateError(e.to_string())); }
+                thread::spawn(move || match pausecat::updater::check_for_updates() {
+                    Ok(info) => {
+                        let _ = event_tx.send(AppEvent::UpdateStatus(info));
+                    }
+                    Err(e) => {
+                        let _ = event_tx.send(AppEvent::UpdateError(e.to_string()));
                     }
                 });
             }
@@ -148,17 +155,21 @@ impl App {
             AppEvent::ThemeChanged(is_dark) => {
                 self.is_dark_mode = is_dark;
                 pausecat::system::set_tray_menu_theme(is_dark);
-                
-                // Broadcast to Settings
                 if let Some(ref mut win) = self.settings_window {
                     win.update_theme(is_dark);
                     pausecat::system::apply_immersive_dark_mode(win.hwnd, is_dark);
                 }
-                // Broadcast to Overlay
                 if let Some(ref mut win) = self.reminder_overlay {
                     win.update_theme(is_dark);
                     pausecat::system::apply_immersive_dark_mode(win.hwnd, is_dark);
                 }
+            }
+            AppEvent::SessionLocked => {
+                self.session_paused.store(true, Ordering::Relaxed);
+                self.reminder_overlay = None;
+            }
+            AppEvent::SessionUnlocked => {
+                self.session_paused.store(false, Ordering::Relaxed);
             }
             AppEvent::Quit => {
                 unsafe { PostQuitMessage(0) };
@@ -171,34 +182,53 @@ impl App {
             bg
         } else {
             if let Ok(captured) = capture::capture_virtual_screen() {
-                let blurred = blur::blur(&captured.data, captured.width as usize, captured.height as usize, 10.0);
+                let blurred = blur::blur(
+                    &captured.data,
+                    captured.width as usize,
+                    captured.height as usize,
+                    10.0,
+                );
                 (captured.width, captured.height, blurred)
-            } else { return; }
+            } else {
+                return;
+            }
         };
 
         let current_settings = self.settings.read().unwrap().clone();
-        if let Ok(overlay) = OverlayWindow::new(self.event_tx.clone(), width, height, data, current_settings) {
+        if let Ok(overlay) =
+            OverlayWindow::new(self.event_tx.clone(), width, height, data, current_settings)
+        {
             overlay.update_theme(self.is_dark_mode);
             pausecat::system::apply_immersive_dark_mode(overlay.hwnd, self.is_dark_mode);
             overlay.fade_in();
             self.reminder_overlay = Some(overlay);
         }
-        
+
         let mut lock = self.pre_captured_bg.write().unwrap();
         *lock = None;
     }
 
     fn pause_media(&mut self) {
         unsafe {
-            let _ = SendMessageW(HWND_BROADCAST, WM_APPCOMMAND, Some(WPARAM(0)), Some(LPARAM(47 << 16)));
+            let _ = SendMessageW(
+                HWND_BROADCAST,
+                WM_APPCOMMAND,
+                Some(WPARAM(0)),
+                Some(LPARAM(47 << 16)),
+            );
         }
-        self.was_media_playing = true; 
+        self.was_media_playing = true;
     }
 
     fn resume_media(&mut self) {
         if self.was_media_playing {
             unsafe {
-                let _ = SendMessageW(HWND_BROADCAST, WM_APPCOMMAND, Some(WPARAM(0)), Some(LPARAM(46 << 16)));
+                let _ = SendMessageW(
+                    HWND_BROADCAST,
+                    WM_APPCOMMAND,
+                    Some(WPARAM(0)),
+                    Some(LPARAM(46 << 16)),
+                );
             }
             self.was_media_playing = false;
         }
@@ -216,12 +246,16 @@ fn setup_logging() -> windows::core::Result<()> {
     path.push("PauseCat");
     let _ = std::fs::create_dir_all(&path);
     path.push("app.log");
-    
+
     let file = std::fs::OpenOptions::new()
         .create(true)
         .append(true)
         .open(&path)
-        .map_err(|e| windows::core::Error::from_hresult(windows::core::HRESULT(e.raw_os_error().unwrap_or(-1) as i32)))?;
+        .map_err(|e| {
+            windows::core::Error::from_hresult(windows::core::HRESULT(
+                e.raw_os_error().unwrap_or(-1) as i32,
+            ))
+        })?;
 
     let target = Box::new(file);
     env_logger::Builder::from_default_env()
@@ -237,7 +271,10 @@ fn check_webview2() -> windows::core::Result<bool> {
     use webview2_com::Microsoft::Web::WebView2::Win32::*;
     unsafe {
         let mut version = windows::core::PWSTR::null();
-        let result = GetAvailableCoreWebView2BrowserVersionString(windows::core::PCWSTR::null(), &mut version);
+        let result = GetAvailableCoreWebView2BrowserVersionString(
+            windows::core::PCWSTR::null(),
+            &mut version,
+        );
         Ok(result.is_ok())
     }
 }
@@ -247,7 +284,11 @@ fn main() -> windows::core::Result<()> {
 
     unsafe {
         use windows::Win32::System::Threading::CreateMutexW;
-        let _handle = CreateMutexW(None, true, windows::core::w!("Global\\PauseCatSingleInstanceMutex"));
+        let _handle = CreateMutexW(
+            None,
+            true,
+            windows::core::w!("Global\\PauseCatSingleInstanceMutex"),
+        );
         if GetLastError() == ERROR_ALREADY_EXISTS {
             return Ok(());
         }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -8,14 +8,26 @@ use crate::settings::Settings;
 use crate::overlay::{capture, blur};
 use crate::system;
 
+pub fn sleep_interruptible(duration: Duration, paused: &AtomicBool) {
+    let start = Instant::now();
+    while start.elapsed() < duration {
+        if paused.load(Ordering::Relaxed) {
+            thread::sleep(Duration::from_millis(100));
+            continue;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+}
+
 pub fn run(settings: Arc<RwLock<Settings>>, event_tx: Sender<AppEvent>, paused: Arc<AtomicBool>) {
-    run_optimized(settings, event_tx, paused, Arc::new(RwLock::new(None)));
+    run_optimized(settings, event_tx, paused, Arc::new(AtomicBool::new(false)), Arc::new(RwLock::new(None)));
 }
 
 pub fn run_optimized(
     settings: Arc<RwLock<Settings>>, 
     event_tx: Sender<AppEvent>, 
     paused: Arc<AtomicBool>,
+    session_paused: Arc<AtomicBool>,
     pre_captured_bg: Arc<RwLock<Option<(i32, i32, Vec<u8>)>>>
 ) {
     let mut last_tick = Instant::now();
@@ -51,7 +63,8 @@ pub fn run_optimized(
             }
         }
         
-        if paused.load(Ordering::Relaxed) {
+        // PAUSE CHECK: Manual Pause OR Session Lock
+        if paused.load(Ordering::Relaxed) || session_paused.load(Ordering::Relaxed) {
             last_tick = Instant::now();
             continue;
         }
@@ -65,7 +78,6 @@ pub fn run_optimized(
             if !is_breaking && time_remaining.as_secs() <= 5 && !pre_capture_triggered {
                 pre_capture_triggered = true;
                 
-                // Whitelist Check before pre-capture
                 let should_skip = {
                     let s = settings.read().unwrap();
                     if let Some(fg_process) = system::get_foreground_process_name() {
@@ -76,7 +88,6 @@ pub fn run_optimized(
                 };
 
                 if should_skip {
-                    // Postpone by 1 minute
                     time_remaining = Duration::from_secs(60);
                     pre_capture_triggered = false;
                     log::info!("Break postponed: Whitelisted app in focus.");
@@ -94,7 +105,6 @@ pub fn run_optimized(
             }
         } else {
             if !is_breaking {
-                // Final Whitelist Check before showing overlay
                 let should_skip = {
                     let s = settings.read().unwrap();
                     if let Some(fg_process) = system::get_foreground_process_name() {
@@ -108,6 +118,11 @@ pub fn run_optimized(
                     time_remaining = Duration::from_secs(60);
                     pre_capture_triggered = false;
                     log::info!("Break skipped: Whitelisted app in focus.");
+                    continue;
+                }
+
+                if session_paused.load(Ordering::Relaxed) {
+                    time_remaining = Duration::from_secs(5);
                     continue;
                 }
 

--- a/src/tray.rs
+++ b/src/tray.rs
@@ -6,6 +6,7 @@ use windows::{
     Win32::UI::WindowsAndMessaging::*,
     Win32::UI::Shell::*,
     Win32::System::LibraryLoader::*,
+    Win32::System::RemoteDesktop::*,
 };
 
 const WM_TRAY_ICON: u32 = WM_APP + 1;
@@ -44,6 +45,9 @@ impl TrayIcon {
                 CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT,
                 None, None, Some(instance), Some(Box::into_raw(Box::new(sender)) as *mut _)
             )?;
+
+            // Register for Session Notifications (Lock/Unlock)
+            let _ = WTSRegisterSessionNotification(hwnd, NOTIFY_FOR_THIS_SESSION);
 
             let h_icon = match LoadImageW(
                 Some(instance),
@@ -100,6 +104,7 @@ impl TrayIcon {
 impl Drop for TrayIcon {
     fn drop(&mut self) {
         unsafe {
+            let _ = WTSUnRegisterSessionNotification(self.hwnd);
             let nid = NOTIFYICONDATAW {
                 cbSize: std::mem::size_of::<NOTIFYICONDATAW>() as u32,
                 hWnd: self.hwnd,
@@ -119,7 +124,6 @@ unsafe extern "system" fn wnd_proc(hwnd: HWND, msg: u32, wparam: WPARAM, lparam:
             let sender = (*create_struct).lpCreateParams;
             SetWindowLongPtrW(hwnd, GWLP_USERDATA, sender as isize);
             
-            // Send initial theme state
             let is_dark = crate::system::is_dark_mode();
             let _ = (&*(sender as *const Sender<AppEvent>)).send(AppEvent::ThemeChanged(is_dark));
             
@@ -131,6 +135,42 @@ unsafe extern "system" fn wnd_proc(hwnd: HWND, msg: u32, wparam: WPARAM, lparam:
                 let sender = &*sender_ptr;
                 let is_dark = crate::system::is_dark_mode();
                 let _ = sender.send(AppEvent::ThemeChanged(is_dark));
+            }
+            LRESULT(0)
+        }
+        WM_WTSSESSION_CHANGE => {
+            let sender_ptr = GetWindowLongPtrW(hwnd, GWLP_USERDATA) as *const Sender<AppEvent>;
+            if !sender_ptr.is_null() {
+                let sender = &*sender_ptr;
+                match wparam.0 as u32 {
+                    WTS_SESSION_LOCK => { 
+                        log::info!("Session Locked: Pausing timer.");
+                        let _ = sender.send(AppEvent::SessionLocked); 
+                    }
+                    WTS_SESSION_UNLOCK => { 
+                        log::info!("Session Unlocked: Resuming timer.");
+                        let _ = sender.send(AppEvent::SessionUnlocked); 
+                    }
+                    _ => {}
+                }
+            }
+            LRESULT(0)
+        }
+        WM_POWERBROADCAST => {
+            let sender_ptr = GetWindowLongPtrW(hwnd, GWLP_USERDATA) as *const Sender<AppEvent>;
+            if !sender_ptr.is_null() {
+                let sender = &*sender_ptr;
+                match wparam.0 as u32 {
+                    PBT_APMSUSPEND => {
+                        log::info!("System Suspending: Pausing timer.");
+                        let _ = sender.send(AppEvent::SessionLocked);
+                    }
+                    PBT_APMRESUMESUSPEND => {
+                        log::info!("System Resumed: Resuming timer.");
+                        let _ = sender.send(AppEvent::SessionUnlocked);
+                    }
+                    _ => {}
+                }
             }
             LRESULT(0)
         }

--- a/wix/main.wxs
+++ b/wix/main.wxs
@@ -2,7 +2,7 @@
      xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui">
   <Package Name="PauseCat"
            Manufacturer="0xarchit"
-           Version="1.0.0"
+           Version="1.0.1"
            UpgradeCode="570a2736-2391-4c12-8e3d-74d32098d57d"
            Language="1033">
 


### PR DESCRIPTION
🐾 Pull Request Description

  Summary
  This PR introduces the "Smart Session Guard," making PauseCat aware of the Windows session state and system power events. It ensures the work timer only ticks when the user is
  actually at their desk and prevents reminders from triggering on locked screens.

  Related Issues
  Fixes #37

  🚀 Key Changes
   - [x] Native Lock Detection: Integrated Win32 WTSRegisterSessionNotification to pause the timer automatically when the screen is locked (Win+L).
   - [x] Power State Awareness: Implemented WM_POWERBROADCAST handling to detect system sleep/suspend and resume events.
   - [x] Zero-Ghosting Guard: Added a strict verification layer that prevents overlay initialization if the user session is not active and unlocked.
   - [x] Automatic Dismiss: Configured the app to automatically clear active break reminders if the session is locked during a break.
   - [x] RAM-Only State: Maintained your preference for non-persistent timers; all session logic lives purely in RAM and resets cleanly upon application restart or system reboot.

  🛠 Technical Details
   - Added Win32_System_RemoteDesktop to Cargo.toml for session change notifications.
   - Refactored the main event loop to route SessionLocked and SessionUnlocked events to the timer engine.
   - Bumped application version to v1.0.1.

  ✅ Verification
   - Verified on Windows 11 that locking the screen instantly freezes the work timer.
   - Confirmed that the timer resumes seamlessly upon unlocking without losing progress.
   - Verified that the break reminder does not trigger while the session is locked.
   - Successfully built with MSVC optimizations (cargo build --release).

  ---
  By submitting this PR, I agree to follow the project's Code of Conduct.