### PR TITLE
feat: implement input sanitization and duration limits #42

### DIFF
--- a/assets/settings.html
+++ b/assets/settings.html
@@ -286,10 +286,10 @@
             <div class="setting-row">
                 <div class="setting-info">
                     <span class="setting-label">Break Duration</span>
-                    <span class="setting-description">Minutes break lasts</span>
+                    <span class="setting-description">Minutes break lasts (Max 120)</span>
                 </div>
                 <div class="control">
-                    <input type="number" id="break_duration" min="1" max="30" step="1">
+                    <input type="number" id="break_duration" min="1" max="120" step="1" oninput="validateBreakDuration()">
                 </div>
             </div>
         </div>
@@ -520,6 +520,18 @@
             }
         };
 
+        function validateBreakDuration() {
+            const input = document.getElementById('break_duration');
+            const val = parseInt(input.value);
+            if (val > 120) {
+                input.style.borderColor = 'var(--danger-text)';
+                input.style.boxShadow = '0 0 0 3px var(--danger-border)';
+            } else {
+                input.style.borderColor = 'var(--border)';
+                input.style.boxShadow = 'none';
+            }
+        }
+
         function updatePreviewFromUI() {
             const bubble = document.getElementById('live-preview-bubble');
             const opacity = parseFloat(document.getElementById('bubble_opacity').value);
@@ -541,9 +553,22 @@
         }
 
         function save() {
+            const workDuration = parseInt(document.getElementById('work_duration').value);
+            const breakDuration = parseInt(document.getElementById('break_duration').value);
+
+            if (breakDuration > 120) {
+                showNotification("Invalid Duration", "Break duration cannot exceed 120 minutes (2 hours).");
+                return;
+            }
+
+            if (workDuration > 240) {
+                showNotification("Invalid Duration", "Work duration cannot exceed 240 minutes (4 hours).");
+                return;
+            }
+
             const settings = {
-                work_duration_secs: document.getElementById('work_duration').value * 60,
-                break_duration_secs: document.getElementById('break_duration').value * 60,
+                work_duration_secs: workDuration * 60,
+                break_duration_secs: breakDuration * 60,
                 mode: document.getElementById('mode').value,
                 autostart: document.getElementById('autostart').checked,
                 overlay_animation: currentMediaPath || "default.webm",

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -92,6 +92,9 @@ impl Settings {
     }
 
     pub fn save(&self) -> Result<(), SettingsError> {
+        let mut settings_to_save = self.clone();
+        settings_to_save.validate();
+
         let dir = Self::get_config_dir();
         if !dir.exists() {
             fs::create_dir_all(&dir)?;
@@ -100,7 +103,7 @@ impl Settings {
         let path = Self::get_config_path();
         let tmp_path = path.with_extension("tmp");
         
-        let json = serde_json::to_string_pretty(self)?;
+        let json = serde_json::to_string_pretty(&settings_to_save)?;
         fs::write(&tmp_path, json)?;
         fs::rename(&tmp_path, &path)?;
 
@@ -110,10 +113,10 @@ impl Settings {
     }
 
     pub fn validate(&mut self) {
-        if self.work_duration_secs < 300 { self.work_duration_secs = 300; }
-        if self.work_duration_secs > 14400 { self.work_duration_secs = 14400; }
-        if self.break_duration_secs < 60 { self.break_duration_secs = 60; }
-        if self.break_duration_secs > 1800 { self.break_duration_secs = 1800; }
+        if self.work_duration_secs < 300 { self.work_duration_secs = 300; } // Min 5m
+        if self.work_duration_secs > 14400 { self.work_duration_secs = 14400; } // Max 4h
+        if self.break_duration_secs < 10 { self.break_duration_secs = 10; } // Min 10s
+        if self.break_duration_secs > 7200 { self.break_duration_secs = 7200; } // Max 2h
         if self.bubble_opacity < 0.0 { self.bubble_opacity = 0.0; }
         if self.bubble_opacity > 1.0 { self.bubble_opacity = 1.0; }
     }

--- a/tests/validation_tests.rs
+++ b/tests/validation_tests.rs
@@ -1,0 +1,58 @@
+#[cfg(test)]
+mod tests {
+    use pausecat::settings::Settings;
+
+    #[test]
+    fn test_break_duration_limits() {
+        let mut settings = Settings::default();
+        
+        // Test normal value
+        settings.break_duration_secs = 600; // 10m
+        settings.validate();
+        assert_eq!(settings.break_duration_secs, 600);
+
+        // Test over limit (should be capped at 7200)
+        settings.break_duration_secs = 10000;
+        settings.validate();
+        assert_eq!(settings.break_duration_secs, 7200);
+
+        // Test under limit (should be capped at 10)
+        settings.break_duration_secs = 5;
+        settings.validate();
+        assert_eq!(settings.break_duration_secs, 10);
+    }
+
+    #[test]
+    fn test_work_duration_limits() {
+        let mut settings = Settings::default();
+        
+        // Test normal value
+        settings.work_duration_secs = 3600; // 1h
+        settings.validate();
+        assert_eq!(settings.work_duration_secs, 3600);
+
+        // Test over limit (should be capped at 14400)
+        settings.work_duration_secs = 20000;
+        settings.validate();
+        assert_eq!(settings.work_duration_secs, 14400);
+
+        // Test under limit (should be capped at 300)
+        settings.work_duration_secs = 100;
+        settings.validate();
+        assert_eq!(settings.work_duration_secs, 300);
+    }
+
+    #[test]
+    fn test_save_sanitization() {
+        let mut settings = Settings::default();
+        settings.break_duration_secs = 99999;
+        settings.work_duration_secs = 99999;
+        
+        // save() internally calls validate() on a clone before writing to disk
+        // We can't easily check the file without side effects, but we can check the logic again
+        let mut clone = settings.clone();
+        clone.validate();
+        assert_eq!(clone.break_duration_secs, 7200);
+        assert_eq!(clone.work_duration_secs, 14400);
+    }
+}


### PR DESCRIPTION
Implements input sanitization and hard limits for work and break durations to ensure system stability and user health.

  Related Issues
  Fixes #42

  🚀 Key Changes
   - [x] Break Duration Limit: Enforced a maximum of 120 minutes (2 hours).
   - [x] Work Duration Limit: Enforced a maximum of 240 minutes (4 hours).
   - [x] Real-time Validation: Added CSS feedback and JS alerts in the settings UI.
   - [x] Backend Sanitization: Updated Settings::validate to ensure consistent state regardless of the input source.

  ✅ Verification
   - Ran cargo check to ensure backend stability.
   - Verified duration limits and UI feedback logic.